### PR TITLE
Support multi-architecture container image builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+Makefile
+_output
+velero-plugin-for-csi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,5 +16,11 @@ jobs:
     - name: Check out the code
       uses: actions/checkout@v1
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2  
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2  
+
     - name: Make ci
       run: make ci

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
 
     - name: Set up Go 1.18

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,12 +39,30 @@ jobs:
     - name: Test
       run: make test
 
+    # Sets the steps output variables: TAG and TAG_LATEST for use by the docker meta step
+    - name: DockerTags
+      id: docker-tags
+      run: |
+        source ./hack/docker-tags.sh
+
+    # Sets an output variable: TAGS with the constructed docker tags
+    - name: DockerMeta
+      id: docker-meta
+      run: |
+        if [ ${{ steps.docker-tags.outputs.TAG_LATEST == true }} ] || if [ ${{ steps.docker-tags.outputs.TAG_LATEST == "true" }} ]
+        then
+          echo "TAGS=ghcr.io/${{ github.repository }}:${{ env.TAG }},ghcr.io/${{ github.repository }}:latest" >> $GITHUB_OUTPUT
+        fi
+        else
+          echo "TAGS=ghcr.io/${{ github.repository }}:${{ env.TAG }}" >> $GITHUB_OUTPUT
+        fi    
+
     - name: Log in to the Container registry
       uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}  
+        password: ${{ secrets.GITHUB_TOKEN }}        
 
     - name: Build and push
       uses: docker/build-push-action@v2
@@ -52,9 +70,9 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        tags: ghcr.io/${{ github.repository }}:${{ steps.repository.outputs.tag }}
+        tags: ${{ steps.docker-meta.outputs.TAGS }}
 
-   # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
+    # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
     - name: Publish container image
       if: github.repository == 'vmware-tanzu/velero-plugin-for-csi'
       run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -50,3 +50,10 @@ jobs:
         platforms: linux/amd64,linux/arm64
         push: true
         tags: ghcr.io/${{ github.repository }}:${{ steps.repository.outputs.tag }}
+
+   # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
+    - name: Publish container image
+      if: github.repository == 'vmware-tanzu/velero-plugin-for-csi'
+      run: |
+        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
+        ./hack/docker-push.sh     

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,17 +24,17 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2  
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2  
+
     - name: Build
       run: make all
 
     - name: Test
       run: make test
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Log in to the Container registry
       uses: docker/login-action@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,10 +29,24 @@ jobs:
 
     - name: Test
       run: make test
-   
-    # Only try to publish the container image from the root repo; forks don't have permission to do so and will always get failures.
-    - name: Publish container image
-      if: github.repository == 'vmware-tanzu/velero-plugin-for-csi'
-      run: |
-        docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}
-        ./hack/docker-push.sh
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}  
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ghcr.io/${{ github.repository }}:${{ steps.repository.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM --platform=$BUILDPLATFORM golang:1.18-buster as build
+ARG TARGETOS
+ARG TARGETARCH
+
+COPY . .
+RUN GOPATH= GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o velero-plugin-for-csi .
+
 FROM busybox:1.34.1-uclibc AS busybox
 
 FROM scratch
-ADD velero-plugin-for-csi /plugins/
 COPY --from=busybox /bin/cp /bin/cp
+COPY --from=build /go/velero-plugin-for-csi /plugins/
 USER 65532:65532
 ENTRYPOINT ["cp", "/plugins/velero-plugin-for-csi", "/target/."]

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ _output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs
 
 TTY := $(shell tty -s && echo "-t")
 
-shell: build-dirs 
+shell: build-dirs
 	@echo "running docker: $@"
 	@docker run \
 		-e GOFLAGS \
@@ -85,16 +85,15 @@ build-dirs:
 
 .PHONY: container
 container: all build-dirs
-	cp Dockerfile _output/bin/$(GOOS)/$(GOARCH)/Dockerfile
-	docker build -t $(IMAGE) -f _output/bin/$(GOOS)/$(GOARCH)/Dockerfile _output/bin/$(GOOS)/$(GOARCH)
+	docker buildx build -f Dockerfile -t $(IMAGE) --platform linux/amd64,linux/arm64 .
+	docker buildx build --load -t $(IMAGE) --platform $(GOOS)/$(GOARCH) .
 
 .PHONY: push
 push: container
 ifeq ($(TAG_LATEST), true)
-	docker tag $(IMAGE_NAME):$(TAG) $(IMAGE_NAME):latest
-	docker push $(IMAGE_NAME):latest
+	docker buildx build --push --platform linux/arm64,linux/amd64 -t $(IMAGE_NAME):latest .
 endif
-	docker push $(IMAGE)
+	docker buildx build --push --platform linux/arm64,linux/amd64 -t $(IMAGE) .
 
 .PHONY: all-ci
 all-ci: $(addprefix ci-, $(BIN))

--- a/hack/docker-tags.sh
+++ b/hack/docker-tags.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Copyright 2020 the Velero contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# docker-push is invoked by the CI/CD system to deploy docker images to Docker Hub.
+# It will build images for all commits to main and all git tags.
+# The highest, non-prerelease semantic version will also be given the `latest` tag.
+
+set +x
+
+if [[ -z "$CI" ]]; then
+    echo "This script is intended to be run only on Github Actions." >&2
+    exit 1
+fi
+
+# Return value is written into HIGHEST
+HIGHEST=""
+function highest_release() {
+    # Loop through the tags since pre-release versions come before the actual versions.
+    # Iterate til we find the first non-pre-release
+
+    # This is not necessarily the most recently made tag; instead, we want it to be the highest semantic version.
+    # The most recent tag could potentially be a lower semantic version, made as a point release for a previous series.
+    # As an example, if v1.3.0 exists and we create v1.2.2, v1.3.0 should still be `latest`.
+    # `git describe --tags $(git rev-list --tags --max-count=1)` would return the most recently made tag.
+
+    for t in $(git tag -l --sort=-v:refname);
+    do
+        # If the tag has alpha, beta or rc in it, it's not "latest"
+        if [[ "$t" == *"beta"* || "$t" == *"alpha"* || "$t" == *"rc"* ]]; then
+            continue
+        fi
+        HIGHEST="$t"
+        break
+    done
+}
+
+triggeredBy=$(echo $GITHUB_REF | cut -d / -f 2)
+if [[ "$triggeredBy" == "heads" ]]; then
+    BRANCH=$(echo $GITHUB_REF | cut -d / -f 3)
+    TAG=
+elif [[ "$triggeredBy" == "tags" ]]; then
+    BRANCH=
+    TAG=$(echo $GITHUB_REF | cut -d / -f 3)
+fi
+
+TAG_LATEST=false
+if [[ ! -z "$TAG" ]]; then
+    echo "We're building tag: $TAG"
+    VERSION="$TAG"
+    # Explicitly checkout tags when building from a git tag.
+    # This is not needed when building from main
+    git fetch --tags
+    # Calculate the latest release if there's a tag.
+    highest_release
+    if [[ "$TAG" == "$HIGHEST" ]]; then
+      TAG_LATEST=true
+    fi
+else
+    echo "We're on branch: $BRANCH"
+    VERSION="$BRANCH"
+    if [[ "$VERSION" == release-* ]]; then
+      VERSION=${VERSION}-dev
+    fi
+fi
+
+TAG="$VERSION" TAG_LATEST="$TAG_LATEST"
+
+echo "TAG=$TAG" >> $GITHUB_OUTPUT
+echo "TAG_LATEST=$TAG_LATEST" >> $GITHUB_OUTPUT
+
+# Debugging info
+echo "Highest tag found: $HIGHEST"
+echo "BRANCH: $BRANCH"
+echo "TAG: $TAG"
+echo "TAG_LATEST: $TAG_LATEST"
+echo "VERSION: $VERSION"


### PR DESCRIPTION
Support multi-architecture container image builds so that velero-plugin-for-csi can be run on amd64 or arm64 architectures

Will publish a container image on github container registry on main branch, release branches or pushes of commits with a tag
